### PR TITLE
Update dist.ini / dzil plugins

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -17,14 +17,15 @@ version = 0.02
 bugtracker = http://rt.cpan.org/NoAuth/Bugs.html?Dist=Dist-Zilla-Plugin-ConsistentVersionTest
 repository = http://hg.urth.org/hg/Dist-Zilla-Plugin-ConsistentVersionTest
 
-[CompileTests]
-[KwaliteeTests]
-[PodTests]
+[Test::Compile]
+[Test::Kwalitee]
+[PodSyntaxTests]
+[Test::Pod::Coverage::Configurable]
 
 [CheckChangeLog]
 [Signature]
 
-[Prereq]
+[Prereqs]
 Dist::Zilla             = 2
 Test::ConsistentVersion = 0
 


### PR DESCRIPTION
A number of plugins have changed names or otherwise become inaccessible
as referenced since we last met; update them.
