### PR TITLE
Add a develop-phase requirement on Test::ConsistentVersion

### DIFF
--- a/corpus/DZ1/dist.ini
+++ b/corpus/DZ1/dist.ini
@@ -1,0 +1,11 @@
+name    = DZ1
+version = 0.001
+author  = E. Xavier Ample <example@example.org>
+license = Perl_5
+copyright_holder = E. Xavier Ample
+
+[@Filter]
+bundle = @FakeClassic
+remove = ConfirmRelease
+remove = FakeRelease
+[FakeUploader]

--- a/corpus/DZ1/lib/DZ1.pm
+++ b/corpus/DZ1/lib/DZ1.pm
@@ -1,0 +1,10 @@
+use strict;
+use warnings;
+package DZ1;
+# ABSTRACT: this is a sample package for testing Dist::Zilla;
+
+sub main {
+  return 1;
+}
+
+1;

--- a/lib/Dist/Zilla/Plugin/ConsistentVersionTest.pm
+++ b/lib/Dist/Zilla/Plugin/ConsistentVersionTest.pm
@@ -8,6 +8,27 @@ use Test::ConsistentVersion;
 use Moose;
 
 extends 'Dist::Zilla::Plugin::InlineFiles';
+with 'Dist::Zilla::Role::PrereqSource';
+
+=head1 METHODS
+
+=head2 register_prereqs
+
+Registers a 'develop' phase requirement for L<Test::ConsistentVersion> with the
+L<Dist::Zilla> object.
+
+=cut
+
+sub register_prereqs {
+    my $self = shift @_;
+
+    $self->zilla->register_prereqs(
+        { phase => 'develop' },
+        'Test::ConsistentVersion' => 0,
+    );
+
+    return;
+}
 
 no Moose;
 

--- a/t/develop-requires.t
+++ b/t/develop-requires.t
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+use Test::More 0.88;
+use Test::DZil;
+
+my $tzil = Builder->from_config(
+    { dist_root => 'corpus/DZ1' },
+    {
+        add_files => {
+            'source/dist.ini' => simple_ini(
+                ('GatherDir', 'ConsistentVersionTest')
+            ),
+        },
+    },
+);
+$tzil->build;
+
+my $prereqs = $tzil->prereqs->as_string_hash;
+ok exists $prereqs->{develop}->{requires}->{'Test::ConsistentVersion'},
+    'Test::ConsistentVersion is a develop prereq',
+    ;
+
+done_testing;


### PR DESCRIPTION
This helps clue things in -- e.g. during a travis-based test run -- that in
order to run this release test, an additional package is needed.
